### PR TITLE
Throw errors instead of returning

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,12 @@ getJSON = function(url) {
   };
   return rp.get(options)
     .catch(function(error) {
-      return error;
+      throw error;
     })
     .then(function(response) {
+      if(response.statusCode !== undefined && response.statusCode !== 200) {
+        throw response;
+      }
       return response;
     });
 };


### PR DESCRIPTION
I was expecting something like
```js
pokedex.getPokemonByName("oweufnwoeindq");
```
to reject, not resolve, as it probably should if you're using promises.

This changes it so if you get a non-200 status code, or the request fails all together, it will reject the promise instead of resolve it. Probably requires a major version bump.

Edit: pokeapi is timing out for me at the moment, so I can't run the tests locally :(